### PR TITLE
Add MarginConfig component and improve margin handling

### DIFF
--- a/app/_components/config-panel/config-editor/css-output/owner-css-output.jsx
+++ b/app/_components/config-panel/config-editor/css-output/owner-css-output.jsx
@@ -11,7 +11,7 @@ export const OwnerCss = (owner) => {
     contentActive.includes("ownerContentPadding")
   ) {
     css += `yt-live-chat-text-message-renderer[author-type="owner"] #content {\n`;
-    if (contentActive.includes("modContentFlexDirection")) {
+    if (contentActive.includes("ownerContentFlexDirection")) {
       css += `  display: flex !important;\n`;
       css += `  flex-direction: ${owner.content.flexDirection} !important;\n`;
     }

--- a/app/_components/config-panel/config-editor/margin-config.jsx
+++ b/app/_components/config-panel/config-editor/margin-config.jsx
@@ -1,0 +1,114 @@
+"use client";
+import React, { useRef } from "react";
+import { Link2, X } from "lucide-react";
+
+export default function MarginConfig({
+  value,
+  setValue,
+  setSync,
+  onDelete,
+  label,
+  prefix,
+}) {
+  const clickedOnce = useRef(false);
+  const defaultValue = { top: 0, right: "", bottom: 0, left: "" };
+  const safeValue = { ...defaultValue, ...value };
+
+  const handleValueChange = (side, rawValue) => {
+    if (side === "left" || side === "right") {
+      // Allow free text for left/right
+      setValue({
+        ...safeValue,
+        [side]: rawValue,
+      });
+    } else {
+      // Only allow numeric values for top/bottom
+      const num = Number(rawValue);
+      if (!isNaN(num)) {
+        setValue({
+          ...safeValue,
+          [side]: num,
+        });
+      }
+    }
+  };
+
+  const handleBlur = (side, rawValue) => {
+    if (side === "left" || side === "right") {
+      const trimmed = rawValue.trim().toLowerCase();
+      const isAuto = trimmed === "auto";
+      const num = Number(trimmed);
+      setValue({
+        ...safeValue,
+        [side]: isAuto ? "auto" : isNaN(num) ? 0 : num,
+      });
+    }
+  };
+
+  const sides = [
+    { label: "Top", value: "top" },
+    { label: "Right", value: "right" },
+    { label: "Bottom", value: "bottom" },
+    { label: "Left", value: "left" },
+  ];
+
+  return (
+    <div className="pt-4 pb-5 border-b group border-white/20 flex flex-col space-y-3">
+      <div className="flex px-4 flex-row justify-between pb-2">
+        <div className="flex flex-row gap-2 items-center">
+          <p className="text-white">{label}</p>
+          {prefix !== "name" && prefix !== "msg" && prefix !== "content" && (
+            <div className="group/sync relative cursor-pointer">
+              <Link2
+                className="group-hover/sync:text-purple-500"
+                size={16}
+                onClick={setSync}
+              />
+              <p className="group-hover/sync:flex hidden py-1 px-2 bg-secondary rounded-sm absolute -bottom-11 left-1/2 -translate-x-1/2 text-nowrap border border-white/30">
+                Sync with Viewer
+              </p>
+            </div>
+          )}
+        </div>
+        <X
+          className="h-full group-hover:opacity-100 opacity-0 cursor-pointer transition-all duration-200 text-red-500"
+          size={17}
+          onClick={onDelete}
+        />
+      </div>
+      <p className="px-4 text-white/40 -mt-4 mb-4">
+        Set Right and Left to "auto" to center chat
+      </p>
+      <div className="grid grid-cols-4 gap-4 px-4">
+        {sides.map((side) => (
+          <div key={side.value} className="flex flex-col">
+            <span className="text-white/70 text-xs mb-2">{side.label}</span>
+            <input
+              type={
+                side.value === "left" || side.value === "right"
+                  ? "text"
+                  : "number"
+              }
+              className="bg-secondary py-1 px-3 rounded text-sm text-white outline-none"
+              value={safeValue[side.value]}
+              onClick={(e) => {
+                if (!clickedOnce.current) {
+                  e.target.select();
+                  clickedOnce.current = true;
+                }
+              }}
+              onBlur={(e) => {
+                clickedOnce.current = false;
+                handleBlur(side.value, e.target.value);
+              }}
+              onChange={(e) => {
+                handleValueChange(side.value, e.target.value);
+              }}
+              style={{ width: 55 }}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/_components/config-panel/config-wrapper.jsx
+++ b/app/_components/config-panel/config-wrapper.jsx
@@ -6,6 +6,7 @@ import FontEditor from "./config-editor/font-config";
 import { OptionsSelector } from "./config-editor/options-selector";
 import CssOutput from "./css-output";
 import FourSideIput from "./config-editor/four-side-input";
+import MarginConfig from "./config-editor/margin-config";
 
 function formatLabel(text) {
   const withSpaces = text.replace(/([A-Z])/g, " $1").trim();
@@ -17,7 +18,7 @@ export default function ConfigWrapper({ roleConfigs, updateRoleConfig }) {
   return (
     <div
       id="config-wrapper"
-      className="max-w-[400px] bg-main flex-1 border-l pt-3 border-secondary rounded-lg"
+      className="max-w-[400px] bg-main flex-1 border-l pt-3 border-secondary "
     >
       <div className="flex flex-row gap-1 pb-2 px-3">
         {["design", "output"].map((m) => (
@@ -85,7 +86,7 @@ function ConfigControls({
     [
       ["fontFamily", "Inter"],
       ["fontColor", defaultColor],
-      ["fontWeight", "500"],
+      ["fontWeight", "400"],
       ["lineHeight", ""],
       ["textAlign", "left"],
       ["fontSize", 15],
@@ -105,8 +106,8 @@ function ConfigControls({
     { label: "Show", value: "block" },
     { label: "Hide", value: "none" },
   ];
-  const defaultMargin = { top: 0, right: 0, bottom: 0, left: 0 };
-  const defaultPadding = { top: 2, right: 2, bottom: 2, left: 2 };
+  const defaultPadding = { top: 0, right: 0, bottom: 0, left: 0 };
+  const defaultMargin = { top: 2, right: 2, bottom: 2, left: 2 };
 
   return (
     <>
@@ -215,7 +216,6 @@ function ConfigControls({
       {config.active.includes(`${prefix}Padding`) && (
         <FourSideIput
           label={formatLabel(`${prefix} Padding`)}
-          configType="padding"
           value={config.padding}
           setSync={() => {
             updateRoleConfig(role, type, "padding", syncConfig.padding);
@@ -238,10 +238,10 @@ function ConfigControls({
           }}
         />
       )}
+
       {config.active.includes(`${prefix}Margin`) && (
-        <FourSideIput
+        <MarginConfig
           label={formatLabel(`${prefix} Margin`)}
-          configType="margin"
           value={config.margin}
           setSync={() => {
             updateRoleConfig(role, type, "margin", syncConfig.margin);
@@ -449,19 +449,22 @@ function ChatConfigPanel({ roleConfigs, updateRoleConfig }) {
       )}
 
       {/* Show fallback if nothing is active */}
-      {!hasViewerConfig && !hasModConfig && !hasMemberConfig && (
-        <div className="px-5 flex flex-col justify-center items-center h-[90vh]">
-          <div className="text-white/40 mx-auto text-sm text-center py-4 leading-snug whitespace-pre">
-            {` ╱|、
+      {!hasViewerConfig &&
+        !hasModConfig &&
+        !hasMemberConfig &&
+        !hasOwnerConfig && (
+          <div className="px-5 flex flex-col justify-center items-center h-[90vh]">
+            <div className="text-white/40 mx-auto text-sm text-center py-4 leading-snug whitespace-pre">
+              {` ╱|、
 (˚ˎ 。7  
          |、˜〵          
   じしˍ,)ノ`}
+            </div>
+            <p className="text-white/40 mx-auto text-sm text-center">
+              No configs were added, try to add from left panel
+            </p>
           </div>
-          <p className="text-white/40 mx-auto text-sm text-center">
-            No configs were added, try to add from left panel
-          </p>
-        </div>
-      )}
+        )}
     </div>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -41,6 +41,9 @@ rz-chat-wrapper {
 rz-chat-wrapper #content {
   row-gap: 16px;
 }
+rz-chat-wrapper {
+  width: 100%;
+}
 rz-chat-wrapper #author-photo {
   margin-right: 16px;
   margin-left: 16px;

--- a/app/page.jsx
+++ b/app/page.jsx
@@ -25,20 +25,25 @@ export default function Home() {
     padding: config.active.includes(`${prefix}Padding`)
       ? `${config.padding.top}px ${config.padding.right}px ${config.padding.bottom}px ${config.padding.left}px`
       : undefined,
-    margin: config.active.includes(`${prefix}Margin`)
-      ? `${config.margin.top}px ${config.margin.right}px ${config.margin.bottom}px ${config.margin.left}px`
-      : undefined,
   });
   const getContentStyle = (config, prefix) => {
     return {
       backgroundColor: config.active.includes(`${prefix}BgColor`)
-        ? config.contentBgColor
+        ? config.bgColor
         : undefined,
 
       display: config.avatar || "block",
       flexDirection: config.flexDirection || "row",
       margin: config.active.includes(`${prefix}Margin`)
-        ? `${config.margin.top}px ${config.margin.right}px ${config.margin.bottom}px ${config.margin.left}px`
+        ? `${config.margin.top}px ${
+            config.margin.right != "auto"
+              ? config.margin.right + "px"
+              : config.margin.right
+          } ${config.margin.bottom}px ${
+            config.margin.left != "auto"
+              ? config.margin.left + "px"
+              : config.margin.left
+          }`
         : undefined,
       padding: config.active.includes(`${prefix}Padding`)
         ? `${config.padding.top}px ${config.padding.right}px ${config.padding.bottom}px ${config.padding.left}px`


### PR DESCRIPTION
Introduces a new MarginConfig component for more flexible margin input, allowing 'auto' values for left/right to enable chat centering. Updates config-wrapper to use MarginConfig, adjusts default margin/padding values, and fixes a bug in owner-css-output for flex direction. Also updates global styles for rz-chat-wrapper width and improves margin style handling in page.jsx.